### PR TITLE
search: Holding Pen ElasticSearch changes

### DIFF
--- a/invenio_workflows/config.py
+++ b/invenio_workflows/config.py
@@ -30,8 +30,65 @@ WORKFLOWS_DATA_PROCESSORS = {
     'marcxml': 'invenio_workflows.manage:split_marcxml',
 }
 
-WORKFLOWS_HOLDING_PEN_INDICES = ["holdingpen"]
-"""The name of the Elasticsearch indices to use for Holding Pen records."""
-
 WORKFLOWS_HOLDING_PEN_DOC_TYPE = "record"
 """The name of the Elasticsearch doc_type to use for Holding Pen records."""
+
+WORKFLOWS_HOLDING_PEN_ES_PREFIX = "holdingpen-"
+"""The prefix name of the Elasticsearch indices to use for Holding Pen.
+For each record index, an equivalent is created for Holding Pen."""
+
+
+WORKFLOWS_HOLDING_PEN_ES_PROPERTIES = {
+    "global_fulltext": {
+        "type": "string",
+        "analyzer": "basic_analyzer"
+    },
+    "global_default": {
+        "type": "string",
+        "analyzer": "basic_analyzer"
+    },
+    "_collections": {
+        "type": "string",
+        "index": "not_analyzed"
+    },
+    "status": {
+        "type": "string",
+        "index": "not_analyzed"
+    },
+    "version": {
+        "type": "string",
+        "index": "not_analyzed"
+    },
+    "type": {
+        "type": "string",
+        "index": "not_analyzed"
+    },
+    "created": {
+        "type": "date"
+    },
+    "modified": {
+        "type": "date"
+    },
+    "uri": {
+        "type": "string",
+        "index": "not_analyzed"
+    },
+    "id_workflow": {
+        "type": "string",
+        "index": "not_analyzed"
+    },
+    "id_user": {
+        "type": "integer",
+        "index": "not_analyzed"
+    },
+    "id_parent": {
+        "type": "integer",
+        "index": "not_analyzed"
+    },
+    "workflow": {
+        "type": "string",
+        "index": "not_analyzed"
+    }
+}
+"""The default properties that should be added to the Holding Pen index
+mappings."""

--- a/invenio_workflows/search.py
+++ b/invenio_workflows/search.py
@@ -21,16 +21,16 @@
 
 from flask import current_app
 
+from invenio_base.globals import cfg
 from invenio_search.api import Query
 
 
 def search(query, sorting={}):
     """Return a set of matched workflow object IDs."""
     results = Query(query)
-    response = results.search()
-    response.index = ",".join(
-        current_app.config.get("WORKFLOWS_HOLDING_PEN_INDICES")
-    )
+    # Disable enhancing to avoid searching in default collection only
+    response = results.search(enhance=False)
+    response.index = cfg['WORKFLOWS_HOLDING_PEN_ES_PREFIX'] + '*'
     response.doc_type = current_app.config.get("WORKFLOWS_HOLDING_PEN_DOC_TYPE")
     if sorting:
         response.body.update(sorting)


### PR DESCRIPTION
* NEW Introduces WORKFLOWS_HOLDING_PEN_ES_PREFIX and
  WORKFLOWS_HOLDING_PEN_ES_PROPERTIES to configure the creation
  of indices related to Holding Pen.

* This allows to store in the Holding Pen records with different
  mappings.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>